### PR TITLE
Import React by default in `connect create` template

### DIFF
--- a/react/src/connect/create.ts
+++ b/react/src/connect/create.ts
@@ -112,6 +112,7 @@ export async function createFigmadocFromUrl({
       logger.info('Generating Code Connect file...')
 
       const figmadoc = `
+import React from 'react';
 import { ${componentName} } from './${componentName}'
 import figma from '@figma/code-connect'
 


### PR DESCRIPTION
I get a warning in my editor when using JSX without React being imported. Not sure if this is an "everyone" thing or a "my company" thing but thought I'd open a PR to start a discussion about whether it should be in the default template. 