### PR TITLE
Fixed SwiftUI code-connect package dependency version

### DIFF
--- a/swiftui/README.md
+++ b/swiftui/README.md
@@ -28,7 +28,7 @@ let package = Package(
     platforms: [...],
     products: [...],
     dependencies: [
-        .package(url: "https://github.com/figma/code-connect", from: "1.0.0"),
+        .package(url: "https://github.com/figma/code-connect", from: "0.1.0"),
     ],
     targets: [...]
 )


### PR DESCRIPTION
The Swift package is actually at version 0.1.0, but the readme erroneously indicates it as 1.0.0. I got a dependency resolution error with 1.0.0. Replacing it with 0.1.0 worked fine.