### PR TITLE
docs: update README.md of Code Connect for React

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -115,6 +115,7 @@ In addition to the [general configuration](../README.md#general-configuration) f
 ```jsonp
 {
   "codeConnect": {
+    "parser": "react",
     "include": [],
     "exclude": ["test/**", "docs/**", "build/**"],
     "importPaths": {


### PR DESCRIPTION
Hello, 
I just added a missing `parser` information in React's README.
On my side, I had an error in my monorepo, that's why I propose to add it.
Thank you.