### PR TITLE
Included custom CLI path for swift tooling to avoid using SPM

### DIFF
--- a/cli/src/connect/parser_executables.ts
+++ b/cli/src/connect/parser_executables.ts
@@ -34,7 +34,11 @@ type ParserInfo = {
 const FIRST_PARTY_PARSERS: Record<FirstPartyExecutableParser, ParserInfo> = {
   swift: {
     command: async (cwd, config, mode) => {
-      return `swift run --package-path ${await getSwiftParserDir(cwd, (config as any).xcodeprojPath)} figma-swift`
+      if (config.customSwiftCLIPath) {
+        return `${config.customSwiftCLIPath}`
+      } else {
+        return `swift run --package-path ${await getSwiftParserDir(cwd, (config as any).xcodeprojPath)} figma-swift`
+      }
     },
   },
   compose: {

--- a/cli/src/connect/project.ts
+++ b/cli/src/connect/project.ts
@@ -56,6 +56,11 @@ type BaseCodeConnectConfig = {
    * Label to use for the uploaded code examples
    */
   label?: string
+
+  /**
+   * Path to the custom Swift parser CLI
+   */
+  customSwiftCLIPath?: string
 }
 
 export type CodeConnectExecutableParserConfig = BaseCodeConnectConfig & {


### PR DESCRIPTION
This PR adds a new custom CLI path configuration that allows you to specify a pre compiled binary and avoid the SwiftSyntax download inside SPM.