### PR TITLE
[fix] Update Swift-Syntax to new URL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .executable(name: "figma-swift", targets: ["CodeConnectCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax", "510.0.3"..."600.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", "510.0.3"..."600.0.1"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.3"),
     ],


### PR DESCRIPTION
Apple has moved swift-syntax to SwiftLang on Github. Changing the URL will result in less issues, as XCode sometimes fails to understand the redirect that github does.