### PR TITLE
[SECURITY FIX] Bump undici to 5.29.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -107,7 +107,7 @@
     "strip-ansi": "^6.0.0",
     "ts-morph": "^23.0.0",
     "typescript": "5.5.4",
-    "undici": "^5.28.4",
+    "undici": "^5.29.0",
     "zod": "3.23.8",
     "zod-validation-error": "^3.2.0"
   }


### PR DESCRIPTION
undici 5.28.x has a known security vulnerability: https://github.com/nodejs/undici/issues/3895

The issue was fixed in 5.29.0 by https://github.com/nodejs/undici/pull/4088
