### PR TITLE
Fixed protocol inheritance for Swift 6.2

### DIFF
--- a/swiftui/sdk/FigmaConnect.swift
+++ b/swiftui/sdk/FigmaConnect.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 /// The protocol that defines what a Code Connect file needs to implement
+@MainActor
 public protocol FigmaConnect: View {
     associatedtype Component: View = AnyView
 


### PR DESCRIPTION
in Swift 6.2 `FigmaConnect` should also be declared as `MainActor` otherwise it will cause warnings (and errors in future versions). 