### PR TITLE
Update swift-syntax dependency version for 602.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .executable(name: "figma-swift", targets: ["CodeConnectCLI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax", "510.0.3"..<"602.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", "510.0.3"..<"603.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.3"),
     ],


### PR DESCRIPTION
swift-syntax 602.0.0 is now out