### PR TITLE
Use individual lodash Node.js modules

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -67,12 +67,13 @@
     "@babel/generator": "7.28.5",
     "@babel/parser": "7.28.5",
     "@babel/types": "7.28.5",
-    
     "@storybook/csf-tools": "8.5.1",
     "@types/cross-spawn": "^6.0.6",
     "@types/jest": "^29.5.13",
     "@types/jsdom": "^21.1.7",
-    "@types/lodash": "4.17.20",
+    "@types/lodash.camelcase": "^4.3.9",
+    "@types/lodash.chunk": "^4.2.9",
+    "@types/lodash.kebabcase": "^4.1.9",
     "@types/node": "22.17.2",
     "@types/prettier": "2.7.3",
     "@types/prompts": "^2.4.9",
@@ -89,8 +90,6 @@
     "webpack-cli": "5.1.4"
   },
   "dependencies": {
-    
-    
     "boxen": "5.1.1",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
@@ -101,7 +100,9 @@
     "find-up": "^5.0.0",
     "glob": "^11.0.4",
     "jsdom": "^24.1.1",
-    "lodash": "4.17.21",
+    "lodash.camelcase": "^4.3.0",
+    "lodash.chunk": "^4.2.0",
+    "lodash.kebabcase": "^4.1.1",
     "minimatch": "^9.0.3",
     "ora": "^5.4.1",
     "parse5": "^7.1.2",

--- a/cli/src/connect/validation.ts
+++ b/cli/src/connect/validation.ts
@@ -1,5 +1,5 @@
 import * as url from 'url'
-import { chunk } from 'lodash'
+import chunk from 'lodash.chunk'
 
 import { CodeConnectJSON } from '../connect/figma_connect'
 import { logger } from '../common/logging'

--- a/cli/src/html/create.ts
+++ b/cli/src/html/create.ts
@@ -7,7 +7,7 @@ import path from 'path'
 import fs from 'fs'
 import { generateProps } from '../react/create'
 import * as prettier from 'prettier'
-import { kebabCase } from 'lodash'
+import kebabCase from 'lodash.kebabcase'
 import { getOutFileName } from '../connect/create_common'
 
 export async function createHtmlCodeConnect(

--- a/cli/src/react/create.ts
+++ b/cli/src/react/create.ts
@@ -1,4 +1,4 @@
-import { camelCase } from 'lodash'
+import camelCase from 'lodash.camelcase'
 import * as prettier from 'prettier'
 import fs from 'fs'
 import z from 'zod'


### PR DESCRIPTION
Hi team,

The lodash dependency is currently pinned to 4.17.21, which has a vulnerability issue in a couple of methods that aren't used in code-connect's codebase ([advisory](https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg)).

This PR replaces the lodash module with individual method modules for the 3 lodash methods used in the codebase:
* lodash.camelcase
* lodash.chunk
* lodash.kebabcase

This should make the package slightly smaller and reduce the chances of needing to bump those packages to keep up with security issues in the future (as it would only be needed if a vulnerability was discovered in those specific method modules rather than anywhere in Lodash's codebase).
