### PR TITLE
feat: support OAuth2 access tokens in addition to PATs

### DIFF
--- a/cli/src/connect/figma_rest_api.ts
+++ b/cli/src/connect/figma_rest_api.ts
@@ -11,9 +11,22 @@ export function getApiUrl(figmaNode: string, apiUrlOverride?: string) {
   return 'https://api.figma.com/v1'
 }
 
+/**
+ * Returns the appropriate headers for Figma API requests.
+ *
+ * Figma supports two authentication methods with different headers:
+ * - Personal Access Tokens (PAT): `X-Figma-Token` header
+ * - OAuth2 access tokens: `Authorization: Bearer` header
+ *
+ * OAuth2 tokens are detected by their `figu_` prefix.
+ *
+ * @see https://developers.figma.com/docs/rest-api/authentication/
+ */
 export function getHeaders(accessToken: string) {
   return {
-    'X-Figma-Token': accessToken,
+    ...(accessToken.startsWith('figu_')
+      ? { Authorization: `Bearer ${accessToken}` }
+      : { 'X-Figma-Token': accessToken }),
     'Content-Type': 'application/json',
     'User-Agent': `code-connect-cli/${version}`,
   }

--- a/cli/src/connect/wizard/run_wizard.ts
+++ b/cli/src/connect/wizard/run_wizard.ts
@@ -2,7 +2,7 @@ import { BaseCommand, getAccessToken, getCodeConnectObjects, getDir } from '../.
 import prompts from 'prompts'
 import fs from 'fs'
 import { exitWithFeedbackMessage, findComponentsInDocument, parseFileKey } from '../helpers'
-import { FigmaRestApi, getApiUrl } from '../figma_rest_api'
+import { FigmaRestApi, getApiUrl, getHeaders } from '../figma_rest_api'
 import { exitWithError, logger, success } from '../../common/logging'
 import {
   ReactProjectInfo,
@@ -105,10 +105,7 @@ async function fetchTopLevelComponentsFromFile({
             ) as CliDataResponse,
           })
         : request.get<CliDataResponse>(apiUrl, {
-            headers: {
-              'X-Figma-Token': accessToken,
-              'Content-Type': 'application/json',
-            },
+            headers: getHeaders(accessToken),
           })
     ).finally(() => {
       if (cmd.verbose) {


### PR DESCRIPTION
## Summary

The CLI currently hardcodes the `X-Figma-Token` header for all API requests, which only works with Personal Access Tokens (PATs). OAuth2 access tokens (prefixed with `figu_`) require the `Authorization: Bearer` header instead ([Figma auth docs](https://developers.figma.com/docs/rest-api/authentication/)).

This change detects OAuth2 tokens by their prefix and uses the correct header, while keeping PATs working exactly as before.

## Changes

- **`cli/src/connect/figma_rest_api.ts`**: Updated `getHeaders()` to detect OAuth2 tokens by their `figu_` prefix and use `Authorization: Bearer` instead of `X-Figma-Token`
- **`cli/src/connect/wizard/run_wizard.ts`**: Replaced duplicated inline header construction with the shared `getHeaders()` function

## Context

Organizations managing Figma tokens centrally via OAuth2 apps cannot use Code Connect today — the CLI always sends `X-Figma-Token`, which Figma rejects for OAuth2 tokens with `403 Invalid token`. This forces every developer to generate individual Personal Access Tokens, defeating the purpose of the OAuth2 app.

Related issue: https://github.com/figma/code-connect/issues/370

## Testing

Verified locally using `yarn patch` against v1.4.1:
- **Before patch**: `403 Invalid token` when using OAuth2 token
- **After patch**: Validation and GET requests succeed with OAuth2 token (confirming the token is valid and the header fix works)

> **Note**: There is a separate server-side issue where `POST /v1/code_connect` rejects OAuth2 tokens with `403 Invalid scope(s)` even when the OAuth2 app has `file_code_connect:write` configured. This PR fixes the CLI side; the API side needs a server-side fix (tracked in the linked issue).