### PR TITLE
Bump swift-syntax upper bound to allow 603.x

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
-        "version" : "510.0.3"
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .executable(name: "figma-swift", targets: ["CodeConnectCLI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax", "510.0.3"..<"603.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", "510.0.3"..<"604.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.3"),
     ],


### PR DESCRIPTION
## Why

The Swift package caps `swift-syntax` at `"510.0.3" ..< "603.0.0"` (Package.swift), which resolves to a **maximum of 602.x**.

SwiftPM resolves every dependency to a single version that satisfies the intersection of *all* constraints in the dependency graph. So when a project depends on both Code Connect **and** `swift-syntax` directly (or via another package), Code Connect's `< 603.0.0` ceiling forces the *entire* graph down to 602.x — even on a Swift 6.3 toolchain, whose matching `swift-syntax` release is **603.x**. In practice this silently **downgrades** swift-syntax in the consuming project, which can break code that relies on 603-only API or simply causes an unwanted version regression.

`swift-syntax` follows the toolchain: 600 → Swift 6.0, 601 → 6.1, … 603 → 6.3. There's no reason for Code Connect to exclude the release that matches the current toolchain.

## What

Raise the upper bound to `604.0.0` so 603.x is allowed:

```diff
-.package(url: "https://github.com/swiftlang/swift-syntax", "510.0.3"..<"603.0.0"),
+.package(url: "https://github.com/swiftlang/swift-syntax", "510.0.3"..<"604.0.0"),
```

The wide lower bound is kept, so older toolchains stay supported — this only *stops capping* below 603.

## Verification

Built and tested against the newly-resolved `swift-syntax` **603.0.1** on Swift 6.3.2:

- `swift build` — clean (only two pre-existing `is`/`as` cast deprecation warnings, unrelated to this change)
- `swift test` — **14/14 tests pass** (`CodeConnectParserTest`, `CodeConnectTemplateWriterTest`, `CodeConnectUploaderTest`)
