### PR TITLE
fix: pass parser command as argv array to avoid space-in-path fragmentation

### DIFF
--- a/cli/src/connect/__test__/parser_executables.test.ts
+++ b/cli/src/connect/__test__/parser_executables.test.ts
@@ -101,6 +101,13 @@ describe('callParser', () => {
 
     const result = await resultPromise
 
+    // Verify spawn was called with a structured cmd+args (not a split string)
+    expect(mockSpawn).toHaveBeenCalledWith(
+      expect.stringContaining('gradlew'),
+      expect.arrayContaining(['-p', '/path/to/gradle', 'parseCodeConnect']),
+      expect.objectContaining({ cwd: '/test/cwd' }),
+    )
+
     // Verify results are combined and deduplicated
     expect(result).toEqual({
       docs: [
@@ -187,6 +194,63 @@ describe('callParser', () => {
     // Verify temp file cleanup
     expect(mockFs.unlinkSync).toHaveBeenCalledWith(
       expect.stringContaining('tmp/figma-code-connect-parser-io.json.tmp'),
+    )
+  })
+
+  it('passes gradle wrapper path containing spaces as a single argv element', async () => {
+    // Regression test for #395: command.split(' ') would fragment paths with spaces
+    mockGetGradleWrapperPath.mockResolvedValue('/path/to/My Project/gradle')
+
+    mockFs.readFileSync = jest.fn().mockReturnValue(
+      JSON.stringify({ docs: [], messages: [] }),
+    )
+
+    const mockChildProcess = createMockChildProcess()
+    mockSpawn.mockReturnValue(mockChildProcess)
+
+    const payload = {
+      mode: 'PARSE' as const,
+      paths: ['/path/to/Component.kt'],
+      config: {},
+    }
+
+    const resultPromise = callParser({ parser: 'compose' as const }, payload, '/test/cwd')
+    setImmediate(() => mockChildProcess.emit('close', 0))
+    await resultPromise
+
+    // The path with a space must arrive as a single element, not fragmented
+    const spawnArgs = mockSpawn.mock.calls[0]
+    expect(spawnArgs[1]).toContain('/path/to/My Project/gradle')
+    expect(spawnArgs[0]).not.toContain(' ')
+  })
+
+  it('invokes custom parser via shell so user quoting is preserved', async () => {
+    const mockChildProcess = createMockChildProcess()
+    mockSpawn.mockReturnValue(mockChildProcess)
+
+    const payload = {
+      mode: 'PARSE' as const,
+      paths: ['/path/to/Component.foo'],
+      config: {},
+    }
+
+    const resultPromise = callParser(
+      { parser: 'custom' as const, parserCommand: 'node "/My Tools/parser.js"' },
+      payload,
+      '/test/cwd',
+    )
+
+    setImmediate(() => {
+      mockChildProcess.stdout.emit('data', JSON.stringify({ docs: [], messages: [] }))
+      mockChildProcess.emit('close', 0)
+    })
+
+    await resultPromise
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'node "/My Tools/parser.js"',
+      [],
+      expect.objectContaining({ shell: true }),
     )
   })
 })

--- a/cli/src/connect/parser_executables.ts
+++ b/cli/src/connect/parser_executables.ts
@@ -25,36 +25,51 @@ import { getComposeErrorSuggestion } from '../parser_scripts/compose_errors'
 const temporaryInputFilePath = 'tmp/figma-code-connect-parser-io.json.tmp'
 const temporaryOutputDirectoryPath = 'tmp/parser-output'
 
+type ParserCommand = { cmd: string; args: string[]; shell?: boolean }
+
 type ParserInfo = {
   command: (
     cwd: string,
     config: CodeConnectExecutableParserConfig | CodeConnectCustomExecutableParserConfig,
     mode: ParserRequestPayload['mode'],
-  ) => Promise<string>
+  ) => Promise<ParserCommand>
   temporaryInputFilePath?: string
   temporaryOutputDirectoryPath?: string
 }
 
 const FIRST_PARTY_PARSERS: Record<CodeConnectExecutableParser, ParserInfo> = {
   swift: {
-    command: async (cwd, config) => {
-      return `swift run --package-path ${await getSwiftParserDir(
-        cwd,
-        (config as any).xcodeprojPath,
-        (config as any).swiftPackagePath,
-        (config as any).sourcePackagesPath,
-      )} figma-swift`
-    },
+    command: async (cwd, config) => ({
+      cmd: 'swift',
+      args: [
+        'run',
+        '--package-path',
+        await getSwiftParserDir(
+          cwd,
+          (config as any).xcodeprojPath,
+          (config as any).swiftPackagePath,
+          (config as any).sourcePackagesPath,
+        ),
+        'figma-swift',
+      ],
+    }),
   },
   compose: {
     command: async (cwd, config, mode) => {
       const gradlewPath = await getGradleWrapperPath(cwd, (config as any).gradleWrapperPath)
       const gradleExecutableInvocation = getGradleWrapperExecutablePath(gradlewPath)
-      const verboseFlags = (config as any).verbose ? ' --stacktrace' : ''
-      if (mode === 'CREATE') {
-        return `${gradleExecutableInvocation} -p ${gradlewPath} createCodeConnect -PfilePath=${temporaryInputFilePath}${verboseFlags} -PoutputDir=${temporaryOutputDirectoryPath}`
-      } else {
-        return `${gradleExecutableInvocation} -p ${gradlewPath} parseCodeConnect -PfilePath=${temporaryInputFilePath}${verboseFlags} -PoutputDir=${temporaryOutputDirectoryPath}`
+      const verboseArgs = (config as any).verbose ? ['--stacktrace'] : []
+      const task = mode === 'CREATE' ? 'createCodeConnect' : 'parseCodeConnect'
+      return {
+        cmd: gradleExecutableInvocation,
+        args: [
+          '-p',
+          gradlewPath,
+          task,
+          `-PfilePath=${temporaryInputFilePath}`,
+          ...verboseArgs,
+          `-PoutputDir=${temporaryOutputDirectoryPath}`,
+        ],
       }
     },
     temporaryInputFilePath: temporaryInputFilePath,
@@ -68,11 +83,13 @@ const FIRST_PARTY_PARSERS: Record<CodeConnectExecutableParser, ParserInfo> = {
         )
       }
       logger.info('Using custom parser command: ' + config.parserCommand)
-      return config.parserCommand
+      // Spawn through the shell so that the user's existing quoting and
+      // environment variable expansion in parserCommand works as expected.
+      return { cmd: config.parserCommand, args: [], shell: true }
     },
   },
   __unit_test__: {
-    command: async () => 'node parser/unit_test_parser.js',
+    command: async () => ({ cmd: 'node', args: ['parser/unit_test_parser.js'] }),
   },
 }
 
@@ -116,11 +133,11 @@ export async function callParser(
         fs.mkdirSync(parser.temporaryOutputDirectoryPath, { recursive: true })
       }
 
-      logger.debug(`Running parser: ${command}`)
-      const commandSplit = command.split(' ')
+      logger.debug(`Running parser: ${command.cmd} ${command.args.join(' ')}`)
 
-      const child = spawn(commandSplit[0], commandSplit.slice(1), {
+      const child = spawn(command.cmd, command.args, {
         cwd,
+        ...(command.shell ? { shell: true } : {}),
       })
 
       let stdout = ''

--- a/cli/src/parser_scripts/get_swift_parser_dir.ts
+++ b/cli/src/parser_scripts/get_swift_parser_dir.ts
@@ -22,14 +22,15 @@ export async function getSwiftParserDir(
   let xcodeprojFile: string | undefined
   let packageSwiftFile: string | undefined
 
-  // // Check for the supported project types giving precedence top the user provided path
+  // Check for the supported project types giving precedence to the user provided path.
+  // Paths are passed as argv elements to spawnSync, so no shell escaping is needed.
   if (xcodeprojPath) {
-    xcodeprojFile = xcodeprojPath.replace(/\s/g, '\\ ')
+    xcodeprojFile = xcodeprojPath
   } else if (swiftPackagePath) {
-    packageSwiftFile = path.dirname(swiftPackagePath).replace(/\s/g, '\\ ')
+    packageSwiftFile = path.dirname(swiftPackagePath)
   } else {
-    xcodeprojFile = getFileIfExists(cwd, '*.xcodeproj').replace(/\s/g, '\\ ')
-    packageSwiftFile = getFileIfExists(cwd, 'Package.swift').replace(/\s/g, '\\ ')
+    xcodeprojFile = getFileIfExists(cwd, '*.xcodeproj')
+    packageSwiftFile = getFileIfExists(cwd, 'Package.swift')
   }
 
   if (!(xcodeprojFile || packageSwiftFile)) {


### PR DESCRIPTION
## Problem

Fixes #395

When any path in the parser invocation contained a space — the gradle wrapper path, a Swift package path, or a user-supplied `parserCommand` — the parser would silently fail or produce the wrong output.

The root cause was in `callParser()`:

```ts
// Before
const commandParts = command.split(' ')
const child = spawn(commandParts[0], commandParts.slice(1), { cwd })
```

`split(' ')` fragments any path that contains a space. A gradle wrapper at `/Users/me/My Project/gradlew` becomes `['/Users/me/My', 'Project/gradlew']`, which is not a valid executable path.

## Fix

Changed `ParserInfo.command` to return a structured `{ cmd, args[], shell? }` object instead of a flat string. Each first-party parser now builds its argument list directly as an array, so no shell-splitting ever occurs.

Custom parsers (`parser: 'custom'`) still go through the shell (`shell: true`) so that the user's existing quoting and environment variable expansion in `parserCommand` is preserved as-is.

Also removed three `replace(/\s/g, '\ ')` calls in `get_swift_parser_dir.ts` that were attempting to escape spaces for shell use — these corrupted argv elements when passed directly to `spawnSync` as array arguments.

## Test plan

- Added regression test: gradle wrapper path with a space arrives as a single argv element (not fragmented)
- Added test: custom parser is spawned with `shell: true` and the full `parserCommand` string as `cmd`
- Updated existing PARSE mode test to assert the structured `spawn(cmd, args, opts)` call shape
- All three new/updated tests pass with `yarn jest parser_executables`