### PR TITLE
Add a release workflow that stages the npm publish

### DIFF
--- a/.github/workflows/finalize.yml
+++ b/.github/workflows/finalize.yml
@@ -1,15 +1,11 @@
 name: Finalize Release
 
-# Tags a release and publishes its GitHub release, after the staged npm publish
-# has been approved.
+# Tags a release and publishes its GitHub release, once the version is live on
+# npm.
 #
-# This is deliberately separate from release.yml. Tagging at staging time would
-# leave a tag and a GitHub release behind for a version that never shipped if a
-# maintainer rejected the staged tarball, and a corrected re-run would then
-# silently keep the stale tag while staging a different commit. Here, npm is the
-# source of truth: nothing is written until the version is actually live.
-#
-# Run this after `npm stage approve` (see release.yml's job summary).
+# Separate from release.yml on purpose: npm is the source of truth here, so a
+# staged publish that was never approved cannot leave a tag or a release behind
+# for a version that does not exist.
 
 on:
   workflow_dispatch:
@@ -47,8 +43,7 @@ jobs:
         with:
           node-version: '22.22.0'
 
-      # The whole point of this workflow: refuse to record a release that npm
-      # does not have. A rejected or still-pending staged publish stops here.
+      # Refuse to record a release that npm does not have.
       - name: Check the version is live on npm
         env:
           VERSION: ${{ inputs.version }}
@@ -56,21 +51,36 @@ jobs:
           if ! OUTPUT=$(npm view "@figma/code-connect@${VERSION}" version 2>&1); then
             echo "::error::@figma/code-connect@${VERSION} is not on npm."
             grep -v '^npm warn' <<<"${OUTPUT}" | head -n 5
-            echo "If it is still staged, approve it first: npm stage approve <stage-id>"
+            echo "If it is still awaiting approval, approve it first."
             exit 1
           fi
           echo "@figma/code-connect@${VERSION} is live on npm."
 
-      # Guard against finalizing a commit that is not the one released: if main
-      # has since moved to a different version, the checkout is the wrong tree to
-      # tag and the notes would not match.
+      # A version match alone is not enough: main can move on without a version
+      # bump (a docs or workflow-only change, or a corrected same-version sync),
+      # and we would then tag the wrong tree and publish its notes. npm records
+      # the exact commit the tarball was built from, so compare against that.
       - name: Check this commit is the released one
         env:
           VERSION: ${{ inputs.version }}
         run: |
+          HEAD_SHA=$(git rev-parse HEAD)
+          GIT_HEAD=$(npm view "@figma/code-connect@${VERSION}" gitHead 2>/dev/null || true)
+
+          if [ -n "${GIT_HEAD}" ]; then
+            if [ "${GIT_HEAD}" != "${HEAD_SHA}" ]; then
+              echo "::error::@figma/code-connect@${VERSION} was published from ${GIT_HEAD}, but HEAD is ${HEAD_SHA}. Re-run this workflow against ${GIT_HEAD}."
+              exit 1
+            fi
+            echo "HEAD matches the published commit."
+            exit 0
+          fi
+
+          # No gitHead recorded; fall back to the weaker version check and say so.
+          echo "::warning::No gitHead recorded for this version; falling back to a version comparison."
           COMMITTED=$(node -p "require('./cli/package.json').version")
           if [ "${COMMITTED}" != "${VERSION}" ]; then
-            echo "::error::main is at ${COMMITTED}, not ${VERSION}. Finalize before syncing the next release, or tag the correct commit by hand."
+            echo "::error::This tree is at ${COMMITTED}, not ${VERSION}."
             exit 1
           fi
 

--- a/.github/workflows/finalize.yml
+++ b/.github/workflows/finalize.yml
@@ -1,0 +1,127 @@
+name: Finalize Release
+
+# Tags a release and publishes its GitHub release, after the staged npm publish
+# has been approved.
+#
+# This is deliberately separate from release.yml. Tagging at staging time would
+# leave a tag and a GitHub release behind for a version that never shipped if a
+# maintainer rejected the staged tarball, and a corrected re-run would then
+# silently keep the stale tag while staging a different commit. Here, npm is the
+# source of truth: nothing is written until the version is actually live.
+#
+# Run this after `npm stage approve` (see release.yml's job summary).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to finalize, e.g. 2.0.1. Must already be live on npm.'
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  finalize:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the tag, create the release
+    steps:
+      - name: Check ref
+        if: github.ref != 'refs/heads/main'
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          echo "::error::Releases must be finalized from main, got ${REF}."
+          exit 1
+
+      - name: Checkout
+        uses: figma/actions-checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - name: Setup node
+        uses: figma/actions-setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '22.22.0'
+
+      # The whole point of this workflow: refuse to record a release that npm
+      # does not have. A rejected or still-pending staged publish stops here.
+      - name: Check the version is live on npm
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! OUTPUT=$(npm view "@figma/code-connect@${VERSION}" version 2>&1); then
+            echo "::error::@figma/code-connect@${VERSION} is not on npm."
+            grep -v '^npm warn' <<<"${OUTPUT}" | head -n 5
+            echo "If it is still staged, approve it first: npm stage approve <stage-id>"
+            exit 1
+          fi
+          echo "@figma/code-connect@${VERSION} is live on npm."
+
+      # Guard against finalizing a commit that is not the one released: if main
+      # has since moved to a different version, the checkout is the wrong tree to
+      # tag and the notes would not match.
+      - name: Check this commit is the released one
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          COMMITTED=$(node -p "require('./cli/package.json').version")
+          if [ "${COMMITTED}" != "${VERSION}" ]; then
+            echo "::error::main is at ${COMMITTED}, not ${VERSION}. Finalize before syncing the next release, or tag the correct commit by hand."
+            exit 1
+          fi
+
+      - name: Tag the release
+        env:
+          VERSION: ${{ inputs.version }}
+          GIT_AUTHOR_NAME: figma-bot
+          GIT_AUTHOR_EMAIL: security@figma.com
+          GIT_COMMITTER_NAME: figma-bot
+          GIT_COMMITTER_EMAIL: security@figma.com
+        run: |
+          HEAD_SHA=$(git rev-parse HEAD)
+
+          if EXISTING=$(git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" 2>/dev/null); then
+            EXISTING_SHA=$(cut -f1 <<<"${EXISTING}")
+            # Annotated tags resolve to their own object, so compare what the tag
+            # points at rather than the tag object itself.
+            git fetch --quiet origin "refs/tags/v${VERSION}:refs/tags/v${VERSION}"
+            TARGET_SHA=$(git rev-parse "v${VERSION}^{commit}")
+            if [ "${TARGET_SHA}" = "${HEAD_SHA}" ]; then
+              echo "Tag v${VERSION} already points at ${HEAD_SHA}; nothing to do."
+              exit 0
+            fi
+            echo "::error::Tag v${VERSION} already exists (${EXISTING_SHA}) but points at ${TARGET_SHA}, not ${HEAD_SHA}."
+            echo "Resolve by hand — do not silently retag a published version."
+            exit 1
+          fi
+
+          git tag -a "v${VERSION}" -m "Code Connect v${VERSION}"
+          git push origin "v${VERSION}"
+          echo "Tagged v${VERSION} at ${HEAD_SHA}."
+
+      # Published, not draft: npm already has the version, so the release is real.
+      - name: Create the GitHub release
+        env:
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "Release v${VERSION} already exists, leaving it alone."
+            exit 0
+          fi
+
+          bash scripts/changelog-section.sh CHANGELOG.md "${VERSION}" > /tmp/release-notes.md
+
+          gh release create "v${VERSION}" \
+            --title "Code Connect ${VERSION}" \
+            --notes-file /tmp/release-notes.md
+
+          {
+            echo "### Released v${VERSION}"
+            echo ""
+            echo "<${{ github.server_url }}/${{ github.repository }}/releases/tag/v${VERSION}>"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/finalize.yml
+++ b/.github/workflows/finalize.yml
@@ -35,54 +35,64 @@ jobs:
           echo "::error::Releases must be finalized from main, got ${REF}."
           exit 1
 
-      - name: Checkout
-        uses: figma/actions-checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-
       - name: Setup node
         uses: figma/actions-setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: '22.22.0'
 
-      # Refuse to record a release that npm does not have.
-      - name: Check the version is live on npm
+      - name: Validate the version
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          if ! OUTPUT=$(npm view "@figma/code-connect@${VERSION}" version 2>&1); then
-            echo "::error::@figma/code-connect@${VERSION} is not on npm."
-            grep -v '^npm warn' <<<"${OUTPUT}" | head -n 5
-            echo "If it is still awaiting approval, approve it first."
+          # Dist-tags and ranges must not reach the registry lookup: "latest"
+          # resolves to a real version whose checks then pass, and we would push
+          # a tag literally named vlatest before the notes lookup failed.
+          if ! printf '%s' "${VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::'${VERSION}' is not an exact X.Y.Z version."
             exit 1
           fi
-          echo "@figma/code-connect@${VERSION} is live on npm."
 
-      # A version match alone is not enough: main can move on without a version
-      # bump (a docs or workflow-only change, or a corrected same-version sync),
-      # and we would then tag the wrong tree and publish its notes. npm records
-      # the exact commit the tarball was built from, so compare against that.
-      - name: Check this commit is the released one
+      - name: Resolve the published commit
+        id: published
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          HEAD_SHA=$(git rev-parse HEAD)
-          GIT_HEAD=$(npm view "@figma/code-connect@${VERSION}" gitHead 2>/dev/null || true)
-
-          if [ -n "${GIT_HEAD}" ]; then
-            if [ "${GIT_HEAD}" != "${HEAD_SHA}" ]; then
-              echo "::error::@figma/code-connect@${VERSION} was published from ${GIT_HEAD}, but HEAD is ${HEAD_SHA}. Re-run this workflow against ${GIT_HEAD}."
-              exit 1
-            fi
-            echo "HEAD matches the published commit."
-            exit 0
-          fi
-
-          # No gitHead recorded; fall back to the weaker version check and say so.
-          echo "::warning::No gitHead recorded for this version; falling back to a version comparison."
-          COMMITTED=$(node -p "require('./cli/package.json').version")
-          if [ "${COMMITTED}" != "${VERSION}" ]; then
-            echo "::error::This tree is at ${COMMITTED}, not ${VERSION}."
+          if ! RESOLVED=$(npm view "@figma/code-connect@${VERSION}" version 2>&1); then
+            echo "::error::@figma/code-connect@${VERSION} is not on npm, or the registry is unreachable."
+            grep -v '^npm warn' <<<"${RESOLVED}" | head -n 5
             exit 1
           fi
+
+          if [ "${RESOLVED}" != "${VERSION}" ]; then
+            echo "::error::Asked for ${VERSION} but npm resolved ${RESOLVED}."
+            exit 1
+          fi
+
+          # Fail closed. Swallowing an error here and falling back to a version
+          # comparison is how a transient registry failure could let the wrong
+          # commit be tagged.
+          if ! GIT_HEAD=$(npm view "@figma/code-connect@${VERSION}" gitHead 2>&1); then
+            echo "::error::Could not read the published commit for ${VERSION}."
+            grep -v '^npm warn' <<<"${GIT_HEAD}" | head -n 5
+            exit 1
+          fi
+
+          if ! printf '%s' "${GIT_HEAD}" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error::No usable commit recorded for ${VERSION}; tag it by hand."
+            exit 1
+          fi
+
+          echo "commit=${GIT_HEAD}" >> "$GITHUB_OUTPUT"
+          echo "@figma/code-connect@${VERSION} was published from ${GIT_HEAD}."
+
+      # Check out what npm actually published, rather than requiring main to
+      # still point at it. main can advance after a release, and demanding a
+      # match there left no way to finish the release at all.
+      - name: Check out the published commit
+        uses: figma/actions-checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          ref: ${{ steps.published.outputs.commit }}
+          fetch-depth: 0
 
       - name: Tag the release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,11 @@
 name: Release
 
-# Stages a release of @figma/code-connect to npm, then tags it and drafts a
-# GitHub release.
+# Stages a release of @figma/code-connect to npm.
+#
+# Tagging and the GitHub release deliberately do NOT happen here — they live in
+# finalize.yml, which runs after the staged publish has been approved. Doing
+# them here would leave a tag and a release behind for a version that was never
+# published if the approval is rejected.
 #
 # Deliberately manual: the commit being released is already on main by the time
 # this runs, and cutting a release is a decision rather than a consequence of a
@@ -29,7 +33,7 @@ on:
         default: 'latest'
         type: string
       dry_run:
-        description: 'Run every check and pack the tarball, but do not stage, tag or draft a release.'
+        description: 'Run every check and pack the tarball, but do not stage anything.'
         required: false
         default: false
         type: boolean
@@ -117,8 +121,14 @@ jobs:
         env:
           VERSION: ${{ needs.authorize.outputs.version }}
         run: |
-          if npm view "@figma/code-connect@${VERSION}" version >/dev/null 2>&1; then
+          # Only a 404 means "not published". Treating any npm failure that way
+          # would let a registry outage wave a duplicate version through.
+          if OUTPUT=$(npm view "@figma/code-connect@${VERSION}" version 2>&1); then
             echo "::error::@figma/code-connect@${VERSION} is already on npm. Bump the version and re-run the release."
+            exit 1
+          elif ! grep -q 'E404' <<<"${OUTPUT}"; then
+            echo "::error::Could not reach the npm registry to check @figma/code-connect@${VERSION}."
+            grep -v '^npm warn' <<<"${OUTPUT}" | head -n 5
             exit 1
           fi
           echo "@figma/code-connect@${VERSION} is not yet published."
@@ -177,12 +187,69 @@ jobs:
         run: npm run test:ci
         working-directory: cli
 
-      - name: Check the package builds and packs
-        run: npm run bundle:npm
+      # Not `npm run bundle:npm`: that script chains the README restore with `;`,
+      # so its exit code is the restore's and a failed build or pack passes. Same
+      # trap as `publish:npm`. Explicit steps, restore under always().
+      - name: Build
+        run: npm run build
+        working-directory: cli
+
+      - name: Swap in the npm README
+        run: npm run bundle:npm-readme:prepare
+        working-directory: cli
+
+      - name: Pack
+        run: npm pack --dry-run
+        working-directory: cli
+
+      - name: Restore the repo README
+        if: always()
+        run: npm run bundle:npm-readme:restore
+        working-directory: cli
+
+  # Rehearsal path. Deliberately outside the npm-release environment: a dry run
+  # only packs a tarball, and should not consume a required reviewer's approval.
+  pack-dry-run:
+    needs: [authorize, verify, test]
+    if: ${{ inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: figma/actions-checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - name: Setup node
+        uses: figma/actions-setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '22.22.0'
+
+      - name: Install
+        run: npm install
+        working-directory: cli
+
+      - name: Build
+        run: npm run build
+        working-directory: cli
+
+      - name: Swap in the npm README
+        run: npm run bundle:npm-readme:prepare
+        working-directory: cli
+
+      - name: Pack
+        run: |
+          npm pack --dry-run
+          echo "Dry run: nothing was staged." >> "$GITHUB_STEP_SUMMARY"
+        working-directory: cli
+
+      - name: Restore the repo README
+        if: always()
+        run: npm run bundle:npm-readme:restore
         working-directory: cli
 
   stage:
     needs: [authorize, verify, test]
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     # Required reviewers on this environment are what authorize a release. npm's
     # trusted publisher is pinned to this environment name too, so its OIDC
@@ -232,19 +299,11 @@ jobs:
         run: npm run bundle:npm-readme:prepare
         working-directory: cli
 
-      - name: Pack (dry run)
-        if: inputs.dry_run
-        run: |
-          npm pack --dry-run
-          echo "Dry run: nothing was staged." >> "$GITHUB_STEP_SUMMARY"
-        working-directory: cli
-
       # Not routed through an npm script: `publish:npm` chains the README
       # restore with `;`, which masks a failing publish behind the restore's exit
       # code. Here a failure has to fail the job.
       - name: Stage the publish
         id: stage
-        if: ${{ !inputs.dry_run }}
         env:
           NPM_CONFIG_TAG: ${{ inputs.dist_tag }}
         run: |
@@ -258,7 +317,6 @@ jobs:
         working-directory: cli
 
       - name: Summarise
-        if: ${{ !inputs.dry_run }}
         env:
           VERSION: ${{ needs.authorize.outputs.version }}
         run: |
@@ -276,56 +334,6 @@ jobs:
             echo "Or use the **Staged Packages** tab on"
             echo "<https://www.npmjs.com/package/@figma/code-connect>."
             echo ""
-            echo "Then publish the draft GitHub release."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  tag-and-release:
-    needs: [authorize, stage]
-    if: ${{ !inputs.dry_run }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # push the tag, create the release
-    steps:
-      - name: Checkout
-        uses: figma/actions-checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-
-      - name: Tag the release
-        env:
-          VERSION: ${{ needs.authorize.outputs.version }}
-          GIT_AUTHOR_NAME: figma-bot
-          GIT_AUTHOR_EMAIL: security@figma.com
-          GIT_COMMITTER_NAME: figma-bot
-          GIT_COMMITTER_EMAIL: security@figma.com
-        run: |
-          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
-            echo "Tag v${VERSION} already exists, leaving it alone."
-            exit 0
-          fi
-          git tag -a "v${VERSION}" -m "Code Connect v${VERSION}"
-          git push origin "v${VERSION}"
-
-      # Draft, not published: the release is only real once the staged npm
-      # publish has been approved, and that is a separate human action.
-      - name: Draft the GitHub release
-        env:
-          VERSION: ${{ needs.authorize.outputs.version }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if gh release view "v${VERSION}" >/dev/null 2>&1; then
-            echo "Release v${VERSION} already exists, leaving it alone."
-            exit 0
-          fi
-
-          bash scripts/changelog-section.sh CHANGELOG.md "${VERSION}" > /tmp/release-notes.md
-
-          gh release create "v${VERSION}" \
-            --draft \
-            --title "Code Connect ${VERSION}" \
-            --notes-file /tmp/release-notes.md
-
-          {
-            echo "### Drafted release v${VERSION}"
-            echo ""
-            echo "Publish it once the npm publish is approved:"
-            echo "<${{ github.server_url }}/${{ github.repository }}/releases>"
+            echo "Once it is live, run the Finalize Release workflow to tag"
+            echo "v${VERSION} and publish its GitHub release."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,12 +159,25 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # 18.x is advisory, not required. package.json advertises engines.node
+    # ">=18", but undici@^7 needs >=20.18.1, so Node 18 may fail for reasons
+    # that predate any given release. Running it non-blocking gives us the real
+    # signal without a known-broken job gating every publish.
+    #
+    # Once the undici/engines question is settled: if we keep Node 18 support
+    # (pin undici back to ^6), set required to true here. If we drop it, raise
+    # engines.node and the quickstart guide, and delete this entry.
+    continue-on-error: ${{ !matrix.required }}
     strategy:
       fail-fast: false
       matrix:
-        # 20.18.1 is the real floor: undici@^7 requires it, even though
-        # package.json still advertises engines.node ">=18".
-        node-version: ['20.18.1', '22.22.0']
+        include:
+          - node-version: '18.x'
+            required: false
+          - node-version: '20.18.1'
+            required: true
+          - node-version: '22.22.0'
+            required: true
     steps:
       - name: Checkout
         uses: figma/actions-checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,331 @@
+name: Release
+
+# Stages a release of @figma/code-connect to npm, then tags it and drafts a
+# GitHub release.
+#
+# Deliberately manual: the commit being released is already on main by the time
+# this runs, and cutting a release is a decision rather than a consequence of a
+# push.
+#
+# This workflow only ever *stages* the npm publish. Its trusted publisher is
+# configured stage-only, so `npm publish` from CI is rejected by the registry; a
+# maintainer completes the release with `npm stage approve`, which requires 2FA
+# and cannot be done with a CI token.
+#
+# Do not move the staging step into a reusable workflow: npm validates the
+# *calling* workflow's filename against the trusted publisher, so `workflow_call`
+# indirection breaks authentication. Renaming this file also breaks it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 2.0.1. Asserted against cli/package.json; leave blank to use whatever is committed.'
+        required: false
+        type: string
+      dist_tag:
+        description: 'npm dist-tag to stage under.'
+        required: false
+        default: 'latest'
+        type: string
+      dry_run:
+        description: 'Run every check and pack the tarball, but do not stage, tag or draft a release.'
+        required: false
+        default: false
+        type: boolean
+
+# Least privilege by default; each job opts in to what it needs.
+permissions: {}
+
+# Never let two releases interleave.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      # The npm-release environment restricts deployments to main as well, but
+      # failing here gives a clearer error than a rejected deployment.
+      - name: Check ref
+        if: github.ref != 'refs/heads/main'
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          echo "::error::Releases must be dispatched from main, got ${REF}."
+          exit 1
+
+      # Defence in depth. Triggering workflow_dispatch already requires write
+      # access, and the npm-release environment's required reviewers are the real
+      # gate — this just fails fast for someone who is not a release maintainer,
+      # rather than leaving a run queued for approval. Set the
+      # RELEASE_DISPATCHERS repo variable to a comma-separated list of GitHub
+      # usernames to enable it.
+      - name: Check actor
+        env:
+          DISPATCHERS: ${{ vars.RELEASE_DISPATCHERS }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          if [ -z "${DISPATCHERS}" ]; then
+            echo "RELEASE_DISPATCHERS is not set; relying on the npm-release environment reviewers."
+            exit 0
+          fi
+          if ! printf '%s' "${DISPATCHERS}" | tr ',' '\n' | sed 's/[[:space:]]//g' | grep -qxF "${ACTOR}"; then
+            echo "::error::${ACTOR} is not in RELEASE_DISPATCHERS."
+            exit 1
+          fi
+          echo "${ACTOR} is an authorized release dispatcher."
+
+      - name: Checkout
+        uses: figma/actions-checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - name: Resolve version
+        id: version
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          VERSION=$(node -p "require('./cli/package.json').version")
+
+          if [ -n "${REQUESTED_VERSION}" ] && [ "${REQUESTED_VERSION}" != "${VERSION}" ]; then
+            echo "::error::Requested ${REQUESTED_VERSION} but cli/package.json is ${VERSION}."
+            exit 1
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Releasing @figma/code-connect@${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+
+  verify:
+    needs: authorize
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: figma/actions-checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - name: Setup node
+        uses: figma/actions-setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '22.22.0'
+
+      - name: Check the version is not already published
+        env:
+          VERSION: ${{ needs.authorize.outputs.version }}
+        run: |
+          if npm view "@figma/code-connect@${VERSION}" version >/dev/null 2>&1; then
+            echo "::error::@figma/code-connect@${VERSION} is already on npm. Bump the version and re-run the release."
+            exit 1
+          fi
+          echo "@figma/code-connect@${VERSION} is not yet published."
+
+      - name: Check the CHANGELOG
+        env:
+          VERSION: ${{ needs.authorize.outputs.version }}
+        run: |
+          if [ ! -f scripts/changelog-section.sh ]; then
+            echo "::error::scripts/changelog-section.sh is missing; cannot build the release notes."
+            exit 1
+          fi
+
+          NOTES=$(bash scripts/changelog-section.sh CHANGELOG.md "${VERSION}")
+          if [ -z "${NOTES}" ]; then
+            echo "::error::The CHANGELOG section for v${VERSION} is empty."
+            exit 1
+          fi
+
+          {
+            echo "### Release notes for v${VERSION}"
+            echo ""
+            printf '%s\n' "${NOTES}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  test:
+    needs: authorize
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # 20.18.1 is the real floor: undici@^7 requires it, even though
+        # package.json still advertises engines.node ">=18".
+        node-version: ['20.18.1', '22.22.0']
+    steps:
+      - name: Checkout
+        uses: figma/actions-checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - name: Setup node ${{ matrix.node-version }}
+        uses: figma/actions-setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # There is no committed lockfile, so `npm install` rather than `npm ci`.
+      - name: Install
+        run: npm install
+        working-directory: cli
+
+      - name: Typecheck
+        run: npm run typecheck
+        working-directory: cli
+
+      - name: Test
+        run: npm run test:ci
+        working-directory: cli
+
+      - name: Check the package builds and packs
+        run: npm run bundle:npm
+        working-directory: cli
+
+  stage:
+    needs: [authorize, verify, test]
+    runs-on: ubuntu-latest
+    # Required reviewers on this environment are what authorize a release. npm's
+    # trusted publisher is pinned to this environment name too, so its OIDC
+    # token claim is checked registry-side — a run that bypassed this gate
+    # cannot stage.
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write # REQUIRED for trusted publishing
+    outputs:
+      staged: ${{ steps.stage.outputs.staged }}
+    steps:
+      - name: Checkout
+        uses: figma/actions-checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - name: Setup node
+        uses: figma/actions-setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '22.22.0'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Staged publishing needs npm >= 11.15.0, which is newer than the npm
+      # bundled with Node 22.
+      - name: Setup npm
+        run: |
+          REQUIRED=11.15.0
+          npm install -g "npm@^${REQUIRED}"
+          NPM_VERSION="$(npm --version)"
+          echo "npm ${NPM_VERSION}"
+          if [ "$(printf '%s\n%s\n' "${REQUIRED}" "${NPM_VERSION}" | sort -V | head -1)" != "${REQUIRED}" ]; then
+            echo "::error::npm ${NPM_VERSION} is too old for staged publishing; need >= ${REQUIRED}."
+            exit 1
+          fi
+
+      - name: Install
+        run: npm install
+        working-directory: cli
+
+      - name: Build
+        run: npm run build
+        working-directory: cli
+
+      # The published README is the repo root one, not cli/README.md. Swapping it
+      # in has to happen before packing, and has to be undone afterwards even on
+      # failure, hence the separate always() step below.
+      - name: Swap in the npm README
+        run: npm run bundle:npm-readme:prepare
+        working-directory: cli
+
+      - name: Pack (dry run)
+        if: inputs.dry_run
+        run: |
+          npm pack --dry-run
+          echo "Dry run: nothing was staged." >> "$GITHUB_STEP_SUMMARY"
+        working-directory: cli
+
+      # Not routed through an npm script: `publish:npm` chains the README
+      # restore with `;`, which masks a failing publish behind the restore's exit
+      # code. Here a failure has to fail the job.
+      - name: Stage the publish
+        id: stage
+        if: ${{ !inputs.dry_run }}
+        env:
+          NPM_CONFIG_TAG: ${{ inputs.dist_tag }}
+        run: |
+          npm stage publish --access public --provenance
+          echo "staged=true" >> "$GITHUB_OUTPUT"
+        working-directory: cli
+
+      - name: Restore the repo README
+        if: always()
+        run: npm run bundle:npm-readme:restore
+        working-directory: cli
+
+      - name: Summarise
+        if: ${{ !inputs.dry_run }}
+        env:
+          VERSION: ${{ needs.authorize.outputs.version }}
+        run: |
+          {
+            echo "### Staged @figma/code-connect@${VERSION}"
+            echo ""
+            echo "Not published yet. A maintainer must approve it with 2FA:"
+            echo ""
+            echo '```sh'
+            echo "npm stage list @figma/code-connect"
+            echo "npm stage download <stage-id>   # optional, inspect the tarball"
+            echo "npm stage approve <stage-id>    # prompts for 2FA"
+            echo '```'
+            echo ""
+            echo "Or use the **Staged Packages** tab on"
+            echo "<https://www.npmjs.com/package/@figma/code-connect>."
+            echo ""
+            echo "Then publish the draft GitHub release."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  tag-and-release:
+    needs: [authorize, stage]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the tag, create the release
+    steps:
+      - name: Checkout
+        uses: figma/actions-checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - name: Tag the release
+        env:
+          VERSION: ${{ needs.authorize.outputs.version }}
+          GIT_AUTHOR_NAME: figma-bot
+          GIT_AUTHOR_EMAIL: security@figma.com
+          GIT_COMMITTER_NAME: figma-bot
+          GIT_COMMITTER_EMAIL: security@figma.com
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists, leaving it alone."
+            exit 0
+          fi
+          git tag -a "v${VERSION}" -m "Code Connect v${VERSION}"
+          git push origin "v${VERSION}"
+
+      # Draft, not published: the release is only real once the staged npm
+      # publish has been approved, and that is a separate human action.
+      - name: Draft the GitHub release
+        env:
+          VERSION: ${{ needs.authorize.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "Release v${VERSION} already exists, leaving it alone."
+            exit 0
+          fi
+
+          bash scripts/changelog-section.sh CHANGELOG.md "${VERSION}" > /tmp/release-notes.md
+
+          gh release create "v${VERSION}" \
+            --draft \
+            --title "Code Connect ${VERSION}" \
+            --notes-file /tmp/release-notes.md
+
+          {
+            echo "### Drafted release v${VERSION}"
+            echo ""
+            echo "Publish it once the npm publish is approved:"
+            echo "<${{ github.server_url }}/${{ github.repository }}/releases>"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,15 @@
 name: Release
 
-# Stages a release of @figma/code-connect to npm.
+# Stages a release of @figma/code-connect to npm, for a maintainer to approve.
 #
-# Tagging and the GitHub release deliberately do NOT happen here — they live in
-# finalize.yml, which runs after the staged publish has been approved. Doing
-# them here would leave a tag and a release behind for a version that was never
-# published if the approval is rejected.
+# Tagging and the GitHub release happen separately, in finalize.yml, once the
+# staged publish has been approved.
 #
-# Deliberately manual: the commit being released is already on main by the time
-# this runs, and cutting a release is a decision rather than a consequence of a
-# push.
-#
-# This workflow only ever *stages* the npm publish. Its trusted publisher is
-# configured stage-only, so `npm publish` from CI is rejected by the registry; a
-# maintainer completes the release with `npm stage approve`, which requires 2FA
-# and cannot be done with a CI token.
-#
-# Do not move the staging step into a reusable workflow: npm validates the
-# *calling* workflow's filename against the trusted publisher, so `workflow_call`
-# indirection breaks authentication. Renaming this file also breaks it.
+# Two constraints to preserve when editing:
+#   - Do not rename this file, and do not move the staging step into a reusable
+#     workflow. npm resolves trusted publishing against this workflow's own
+#     filename, so either change breaks authentication.
+#   - Keep the staging job's `environment` as it is; npm checks it too.
 
 on:
   workflow_dispatch:
@@ -64,26 +55,19 @@ jobs:
           echo "::error::Releases must be dispatched from main, got ${REF}."
           exit 1
 
-      # Defence in depth. Triggering workflow_dispatch already requires write
-      # access, and the npm-release environment's required reviewers are the real
-      # gate — this just fails fast for someone who is not a release maintainer,
-      # rather than leaving a run queued for approval. Set the
-      # RELEASE_DISPATCHERS repo variable to a comma-separated list of GitHub
-      # usernames to enable it.
+      # Optional early check against the RELEASE_DISPATCHERS repo variable, so an
+      # unauthorized dispatch fails immediately rather than queueing. Logs here
+      # are public, so this reports nothing about how it is configured.
       - name: Check actor
         env:
           DISPATCHERS: ${{ vars.RELEASE_DISPATCHERS }}
           ACTOR: ${{ github.actor }}
         run: |
-          if [ -z "${DISPATCHERS}" ]; then
-            echo "RELEASE_DISPATCHERS is not set; relying on the npm-release environment reviewers."
-            exit 0
-          fi
-          if ! printf '%s' "${DISPATCHERS}" | tr ',' '\n' | sed 's/[[:space:]]//g' | grep -qxF "${ACTOR}"; then
-            echo "::error::${ACTOR} is not in RELEASE_DISPATCHERS."
+          if [ -n "${DISPATCHERS}" ] &&
+            ! printf '%s' "${DISPATCHERS}" | tr ',' '\n' | sed 's/[[:space:]]//g' | grep -qxF "${ACTOR}"; then
+            echo "::error::${ACTOR} is not authorized to dispatch a release."
             exit 1
           fi
-          echo "${ACTOR} is an authorized release dispatcher."
 
       - name: Checkout
         uses: figma/actions-checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -159,14 +143,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # 18.x is advisory, not required. package.json advertises engines.node
-    # ">=18", but undici@^7 needs >=20.18.1, so Node 18 may fail for reasons
-    # that predate any given release. Running it non-blocking gives us the real
-    # signal without a known-broken job gating every publish.
-    #
-    # Once the undici/engines question is settled: if we keep Node 18 support
-    # (pin undici back to ^6), set required to true here. If we drop it, raise
-    # engines.node and the quickstart guide, and delete this entry.
+    # 18.x runs for signal but does not gate a release: a dependency in the
+    # tree currently needs a newer Node than package.json's engines field
+    # advertises, so 18 can fail for reasons unrelated to the release being cut.
+    # Set its `required` to true once that is reconciled.
     continue-on-error: ${{ !matrix.required }}
     strategy:
       fail-fast: false
@@ -264,10 +244,7 @@ jobs:
     needs: [authorize, verify, test]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
-    # Required reviewers on this environment are what authorize a release. npm's
-    # trusted publisher is pinned to this environment name too, so its OIDC
-    # token claim is checked registry-side — a run that bypassed this gate
-    # cannot stage.
+    # Gated environment; npm checks this name too. See the internal runbook.
     environment: npm-release
     permissions:
       contents: read
@@ -319,34 +296,33 @@ jobs:
         id: stage
         env:
           NPM_CONFIG_TAG: ${{ inputs.dist_tag }}
+          VERSION: ${{ needs.authorize.outputs.version }}
         run: |
           npm stage publish --access public --provenance
           echo "staged=true" >> "$GITHUB_OUTPUT"
+
+          # Written here, not in a later step: if cleanup below fails, the job
+          # goes red but the version IS staged, and whoever picks it up needs to
+          # know that before re-running.
+          {
+            echo "### Staged @figma/code-connect@${VERSION}"
+            echo ""
+            echo "Awaiting maintainer approval. It is not published yet."
+            echo ""
+            echo '```sh'
+            echo "npm stage list @figma/code-connect"
+            echo "npm stage download <stage-id>   # optional, inspect the tarball"
+            echo "npm stage approve <stage-id>"
+            echo '```'
+            echo ""
+            echo "If a later step in this job failed, the version is still staged:"
+            echo "approve or reject the existing entry rather than re-running."
+            echo ""
+            echo "Once it is live, run the Finalize Release workflow."
+          } >> "$GITHUB_STEP_SUMMARY"
         working-directory: cli
 
       - name: Restore the repo README
         if: always()
         run: npm run bundle:npm-readme:restore
         working-directory: cli
-
-      - name: Summarise
-        env:
-          VERSION: ${{ needs.authorize.outputs.version }}
-        run: |
-          {
-            echo "### Staged @figma/code-connect@${VERSION}"
-            echo ""
-            echo "Not published yet. A maintainer must approve it with 2FA:"
-            echo ""
-            echo '```sh'
-            echo "npm stage list @figma/code-connect"
-            echo "npm stage download <stage-id>   # optional, inspect the tarball"
-            echo "npm stage approve <stage-id>    # prompts for 2FA"
-            echo '```'
-            echo ""
-            echo "Or use the **Staged Packages** tab on"
-            echo "<https://www.npmjs.com/package/@figma/code-connect>."
-            echo ""
-            echo "Once it is live, run the Finalize Release workflow to tag"
-            echo "v${VERSION} and publish its GitHub release."
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Print the CHANGELOG body for a single Code Connect version.
+#
+# Our CHANGELOG uses a single `#` for version headers and `##` for the sections
+# within a release:
+#
+#   # Code Connect v2.0.0 (18 August 2026)
+#
+#   ## Fixed
+#   - ...
+#
+#   # Code Connect v1.5.3 (12 August 2026)
+#
+# so we print everything after the matching version header up to (but not
+# including) the next `# ` header. The version header itself is omitted, as
+# callers (GitHub releases, Slack posts) already carry the version in a title.
+#
+# Exits 1 if the version has no section, so callers can `set -e` on it.
+#
+# Keep this script dependency free (no node, no tsx): the release workflow calls
+# it before `npm install` has run.
+#
+#
+# Usage: ./scripts/changelog-section.sh CHANGELOG.md 2.0.0
+
+file="${1:?missing changelog file (e.g. CHANGELOG.md)}"
+ver="${2:?missing version (e.g. 2.0.0)}"
+
+section="$(
+  awk -v ver="$ver" '
+    BEGIN {
+      found = 0
+      # Escape dots so "2.0.0" cannot match "2x0y0".
+      gsub(/\./, "\\.", ver)
+      header = "^#[[:space:]]+Code Connect[[:space:]]+v" ver "([[:space:]]|$)"
+    }
+    # Single-hash lines are version headers; "## Fixed" et al. are not matched
+    # here because the second character is "#" rather than whitespace.
+    /^#[[:space:]]/ {
+      if (found) { exit }
+      if ($0 ~ header) { found = 1 }
+      next
+    }
+    found { print }
+    END { if (!found) exit 1 }
+  ' "$file"
+)" || {
+  echo "error: no CHANGELOG section found for version ${ver} in ${file}" >&2
+  exit 1
+}
+
+# Trim leading and trailing blank lines, keeping the interior intact.
+printf '%s\n' "$section" | awk '
+  { lines[NR] = $0 }
+  END {
+    first = 1
+    last = NR
+    while (first <= NR && lines[first] ~ /^[[:space:]]*$/) { first++ }
+    while (last >= first && lines[last] ~ /^[[:space:]]*$/) { last-- }
+    for (i = first; i <= last; i++) { print lines[i] }
+  }
+'


### PR DESCRIPTION
_Written with AI_ — reviewed/edited by @agarbutt-figma

## Summary

Adds a `Release` workflow that stages a publish of `@figma/code-connect` to npm using [trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC), plus a `Finalize Release` workflow that tags the release and publishes its GitHub release once the version is live.


The first CI in this repository, so it doubles as a build and test gate on the commit being released.

## Workflows

**`release.yml`** — manual dispatch, `main` only.

1. `authorize` — resolves the version from `cli/package.json`, asserted against the optional `version` input.
2. `verify` — the version is not already on npm; the CHANGELOG has a non-empty section for it.
3. `test` — `npm install`, `typecheck`, `test:ci`, build and pack, on Node 18.x (non-gating), 20.18.1 and 22.22.0.
4. `stage` / `pack-dry-run` — stages the publish, or just packs a tarball when `dry_run` is set.

It does not tag or create a release.

**`finalize.yml`** — manual dispatch, takes the version. Verifies the version is live on npm and that this commit is the one npm published (via the recorded `gitHead`), then tags `vX.Y.Z` and publishes its GitHub release from the CHANGELOG section. It will not retag an existing version.

## Before this can run

Some repository and registry configuration is required first, and is tracked internally. Please rehearse with `dry_run: true` before the first real release.

<!-- trellis-metadata: {"source":"trellis","session_id":"f12b424d3a7380476ebd4b1e351fa4a7"} -->


